### PR TITLE
changes to prepare_url method

### DIFF
--- a/opsdroidaudio/generators.py
+++ b/opsdroidaudio/generators.py
@@ -14,10 +14,9 @@ def prepare_url(text):
     """Transform url found in text for better voice understanding."""
     text = text.replace("/www.", "/")
     url = re.search(r'(https?:\/\/(\w+.\w+).*)', text)
-    text = text.split(" ")
-    text[text.index(url.group(1))] = "a link to {}".format(url.group(2))
+    text = text.replace(url.group(1), "a link to {}".format(url.group(2)))
 
-    return " ".join(text)
+    return text
 
 
 def google(config, text):


### PR DESCRIPTION
The new changes in 'prepare_url' method fix the bug when the text contains some additional data like something before and after "http://.." as the new changes will replace the URL in a text with " a link to <domain_name>" only.
It is fast and as compare to the works like splitting, modifying and joining the string. 
![error_report](https://user-images.githubusercontent.com/46000505/88188298-45968400-cc55-11ea-9410-a03f349247ce.png)
